### PR TITLE
Remove ID macros

### DIFF
--- a/src/Vector/vector_dist.hpp
+++ b/src/Vector/vector_dist.hpp
@@ -61,10 +61,6 @@ template<unsigned int dim,typename St> using CELLLIST_GPU_SPARSE = CellList_gpu<
 	#define SE_CLASS3_VDIST_CONSTRUCTOR
 #endif
 
-
-#define NO_ID false
-#define ID true
-
 // Perform a ghost get or a ghost put
 constexpr int GET = 1;
 constexpr int PUT = 2;


### PR DESCRIPTION
This pull request removes the unused macros ID and NO_ID, which can cause conflicts when OpenFPM is used alongside the fmt library. Macros with such common names (lacking a unique prefix like OPENFPM_ID) should be avoided to prevent naming collisions like this.